### PR TITLE
Improvements to GitBook/GitHub integration FAQ

### DIFF
--- a/github/can-i-host-on-github.md
+++ b/github/can-i-host-on-github.md
@@ -5,14 +5,14 @@ GitBook integrates perfectly with [GitHub](https://github.com) as a hosting solu
 - The Editor will make changes directly to the GitHub repository
 - GitBook will watch for updates on GitHub and trigger website/pdf updates accordingly
 
-Integrating with GitHub is done in 3 steps:
+Integrating with GitHub is done using the following process:
 
-1. Setting up [permissions](#permissions)
-2. [Linking your book](#linking) to a GitHub repository
-3. Setting up [webhooks](#webhooks)
+1. [Set up permissions](#permissions)
+2. [Export your book to GitHub](#importing)
+2. [Link your book to a GitHub](#linking)
+3. [Set up webhooks](#webhooks)
 
-
-### 1. Setting up permissions {#permissions}
+## 1. Set up permissions {#permissions}
 
 To integrate your book with GitHub, you need to authorize GitBook to access your GitHub account to some extent. From your [account's settings](https://www.gitbook.com/settings), connect your GitHub account and choose what you will allow:
 
@@ -21,21 +21,37 @@ To integrate your book with GitHub, you need to authorize GitBook to access your
 - **Access to private repositories**: Same as above, but for private repositories too.
 - **Access to webhook**: Allows GitBook to create webhooks on your book repositories to trigger builds automatically.
 
+## 2. Use GitHub as your primary book repository 
 
-### 2. Linking your book to a GitHub repository {#linking}
+This process involves two procedures:
 
-From your book's GitHub settings page, you can easily specify to which GitHub repository your book will be linked.
+* [importing your GitBook repository to GitHub](#importing)
+* [linking your GitHub repository with GitBook](#linking)
 
-In the input form, type in the name of your book's repository in the following format:
+### 2.1 Import your book repository to GitHub {#importing}
 
-`<github-username>/<github-repository-name>`
+**NOTE** If you authenticate to GitBook using a SSO service like GitHub or Google, make sure you set a GitBook password in your `Settings` before proceeding. 
+Importing will fail unless you do.
 
-Note that you shouldn't enter neither the full GitHub address, nor the `.git` extension.
+1. On your book's landing page, click **Settings**.
+2. Scroll down to the **Git URL** and copy the path.
+3. Click **GitHub** in the left settings pane.
+4. Click the **Export to GitHub** button.
+5. In the **Old repository's clone URL** field, paste the GitBook Git URL you copied in step 2.
+6. In the **Your new repository details** field, type in the name for your new repository.
+7. Click **Begin Import**.
+8. If prompted for login credentials, these are your GitBook username (typically your email) and your password (you set prior to starting this procedure.
 
-Finally, click on the **Save** button.
+### 2.2 Link your GitHub repository to your GitBook book {#linking}
 
+1. On your book's landing page, click `Settings`.
+2. Click **GitHub**.
+3. Type the name of your exported book repository in the following format: `<github-username>/<github-repository-name>`
+4. Click **Save**
 
-### 3. Setting up webhooks {#webhooks}
+You do not need to enter the full GitHub address, nor the `.git` extension. For example: `GitbookIO/help.gitbook.com` if you were using the source for the GitBook Help FAQ.
+
+## 3. Setting up webhooks {#webhooks}
 
 The final step is to configure a webhook on your GitHub repository that will let GitBook know when your repository is updated.
 


### PR DESCRIPTION
If merged, will implement the following changes:
- Fix section indentation (from three hashes to two).
- Made linking the GitLab book to GitHub a two procedure process.
- Made an explicit note about ensuring you set up a GitBook password so you can start the export process.
- Highlighted the Import Book function for importing books (which is awesome!!)
- updated anchors to make intra-document linking work.
