### PR TITLE
Migrating to help.legacy.gitbook.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 search: false
 ---
 
-Welcome to the help center for the [GitBook.com](https://www.gitbook.com) platform, where you can learn how to create books, collaborate with people, and integrate with other services. If you are looking for details about the GitBook format, visit the [toolchain documentation](http://toolchain.gitbook.com/).
+Welcome to the help center for the **deprecated GitBook.com platform**, that lives at [**legacy**.gitbook.com](https://www.gitbook.com). Customers who have not yet migrated to the new version can still use the legacy service for the duration of the transition. To access the new version documentation, head to [docs.gitbook.com](https://docs.gitbook.com).
+

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 search: false
 ---
 
-Welcome to the help center for the **deprecated GitBook.com platform**, that lives at [**legacy**.gitbook.com](https://www.gitbook.com). Customers who have not yet migrated to the new version can still use the legacy service for the duration of the transition. To access the new version documentation, head to [docs.gitbook.com](https://docs.gitbook.com).
+Welcome to the help center for the **deprecated GitBook.com platform**, that lives at [**legacy**.gitbook.com](https://legacy.gitbook.com). Customers who have not yet migrated to the new version can still use the legacy service for the duration of the transition. To access the new version documentation, head to [docs.gitbook.com](https://docs.gitbook.com).
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,13 +13,11 @@
 ## Accounts & Billing
 
 * [I forgot or lost my password. How do I reset it?](accounts/i-forgot-lost-my-password.md)
-* [What plan should I choose?](accounts/what-plan-should-i-choose.md)
 * [How do I delete my user account?](accounts/how-do-i-delete-account.md)
-* [Will there be a minimum contract with premium plans?](accounts/will-there-be-a-minimal-contract.md)
-* [Are the plans' prices the same worldwide?](accounts/are-prices-same-worldwide.md)
-* [Do you offer education discounts?](accounts/do-you-offer-discounts.md)
+* [Is there a minimum contract with premium plans?](accounts/will-there-be-a-minimal-contract.md)
 * [What payment methods do you accept?](accounts/what-payment-methods-do-you-accept.md)
 * [Why am I getting an error "An account with this email address already exists"?](accounts/why-error-duplicate.md)
+* [I cannot create an account](accounts/i-cannot-create-an-account.md)
 
 ## Books
 

--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,7 +1,7 @@
 {% extends template.self %}
 
 {% block faq_header_brand %}
-<img src="https://www.gitbook.com/assets/images/logo/512-text.png" height="30" />
+<img src="https://legacy.gitbook.com/assets/images/logo/512-text.png" height="30" />
 {% endblock %}
 
 {% block faq_menu %}
@@ -9,8 +9,8 @@
     <li><a href="https://toolchain.gitbook.com" target="_blank">Toolchain</a></li>
     <li><a href="https://developer.gitbook.com" target="_blank">Developers</a></li>
     <li><a>|</a></li>
-    <li><a href="https://www.gitbook.com">GitBook.com</a></li>
-    <li><a href="https://www.gitbook.com/contact" target="_blank">Contact us</a></li>
-    <li><a href="https://www.gitbook.com/book/gitbookio/help/discussions" target="_blank">Suggest a Question</a></li>
+    <li><a href="https://legacy.gitbook.com">GitBook.com</a></li>
+    <li><a href="https://legacy.gitbook.com/contact" target="_blank">Contact us</a></li>
+    <li><a href="https://legacy.gitbook.com/book/gitbookio/help/discussions" target="_blank">Suggest a Question</a></li>
 </ul>
 {% endblock %}

--- a/accounts/do-you-offer-discounts.md
+++ b/accounts/do-you-offer-discounts.md
@@ -12,6 +12,6 @@ Yes, we offer the following discounts:
 | Educational projects     | Up to 100% off the appropriate Organization plan | One year renewable |
 | Non-profit organizations | Up to 100% off the appropriate Organization plan | -                  |
 
-Details about each plan can be found on the [GitBook pricing page](https://www.gitbook.com/pricing). _If you do not have requirement regarding privacy, our free plans are likely to fit your needs_.
+Details about each plan can be found on the [GitBook pricing page](https://legacy.gitbook.com/pricing). _If you do not have requirement regarding privacy, our free plans are likely to fit your needs_.
 
-To apply for a discount, contact us through the [Contact form](https://www.gitbook.com/contact). Please provide your academic email, and if you are representantative of an educational project or a non-profit organization, tell us more about your project and how you plan on using GitBook.
+To apply for a discount, contact us through the [Contact form](https://legacy.gitbook.com/contact). Please provide your academic email, and if you are representantative of an educational project or a non-profit organization, tell us more about your project and how you plan on using GitBook.

--- a/accounts/how-do-i-delete-account.md
+++ b/accounts/how-do-i-delete-account.md
@@ -4,7 +4,7 @@ related:
     - orgs/how-do-i-delete-organization.md
 ---
 
-You can [delete your GitBook user account](https://www.gitbook.com/settings/delete) at any time. Be careful, this operation **CANNOT** be undone.
+You can [delete your GitBook user account](https://legacy.gitbook.com/settings/delete) at any time. Be careful, this operation **CANNOT** be undone.
 
 Before you do so, you should transfer ownership of any organizations you might own. All books owned by your account will be lost, so you might want to transfer them to another user too. However, discussions and comments you have made in other people's books will remain, becoming anonymous (transfered to a "Ghost" user).
 

--- a/accounts/i-cannot-create-an-account.md
+++ b/accounts/i-cannot-create-an-account.md
@@ -1,0 +1,2 @@
+Unless you have an invite to join an existing organization, you cannot create a new account on the legacy platform. Only existing users can otherwise access the legacy platform. If you want to start using GitBook, you should visit the new version at [gitbook.com.](https://www.gitbook.com)
+

--- a/accounts/i-forgot-lost-my-password.md
+++ b/accounts/i-forgot-lost-my-password.md
@@ -1,1 +1,1 @@
-You can reset your password by entering your email on the [**Forgot password**](https://www.gitbook.com/settings/password/reset) page.
+You can reset your password by entering your email on the [**Forgot password**](https://legacy.gitbook.com/settings/password/reset) page.

--- a/accounts/what-plan-should-i-choose.md
+++ b/accounts/what-plan-should-i-choose.md
@@ -1,3 +1,3 @@
-GitBook has paid plans both for individuals and teams (see [our pricing](https://www.gitbook.com/pricing)).
+GitBook has paid plans both for individuals and teams (see [our pricing](https://legacy.gitbook.com/pricing)).
 
 If you are creating content for your company or a team, consider creating and organization and opting for a paid **Organization** plan. Opt for an Individual plan if you don't plan on having any collaborators.

--- a/accounts/why-error-duplicate.md
+++ b/accounts/why-error-duplicate.md
@@ -10,6 +10,6 @@ In this case, you need to **remove** one of these account, to do so:
 
 1. Log out from the account associated with your email
 2. Log in using the social account instead
-3. Delete this account at [www.gitbook.com/settings](https://www.gitbook.com/settings)
+3. Delete this account at [legacy.gitbook.com/settings](https://legacy.gitbook.com/settings)
 4. Log in again using your email
-5. Associate the Social Account to your email account at [www.gitbook.com/settings](https://www.gitbook.com/settings)
+5. Associate the Social Account to your email account at [legacy.gitbook.com/settings](https://legacy.gitbook.com/settings)

--- a/basics/for-api-documentation.md
+++ b/basics/for-api-documentation.md
@@ -1,9 +1,9 @@
 ---
 related:
-    - content/how-can-i-change-theme.md
-
+  - content/how-can-i-change-theme.md
 ---
 
 GitBook is perfectly suited to write API documentation easily. The simplest way is to use [a theme for API documentation](https://plugins.gitbook.com/plugin/theme-api).
 
-Soon, a book template using this theme will also be suggested when creating a book on [GitBook.com](https://www.gitbook.com/).
+Soon, a book template using this theme will also be suggested when creating a book on [GitBook.com](https://legacy.gitbook.com).
+

--- a/basics/for-faq-documentation.md
+++ b/basics/for-faq-documentation.md
@@ -1,9 +1,9 @@
 ---
 related:
-    - content/how-can-i-change-theme.md
-
+  - content/how-can-i-change-theme.md
 ---
 
-You can create an F.A.Q. with [GitBook](https://github.com/GitbookIO/gitbook). As a matter of fact, this Help Center is made with GitBook and hosted on [GitBook.com](https://gitbook.com).
+You can create an F.A.Q. with [GitBook](https://github.com/GitbookIO/gitbook). As a matter of fact, this Help Center is made with GitBook and hosted on [legacy.gitbook.com](https://gitbook.com).
 
 To create an F.A.Q., you can install and use the [theme-faq](https://plugins.gitbook.com/plugin/theme-faq). Soon, you will be able to choose a F.A.Q. template from the book creation page on GitBook.com.
+

--- a/basics/for-faq-documentation.md
+++ b/basics/for-faq-documentation.md
@@ -3,7 +3,7 @@ related:
   - content/how-can-i-change-theme.md
 ---
 
-You can create an F.A.Q. with [GitBook](https://github.com/GitbookIO/gitbook). As a matter of fact, this Help Center is made with GitBook and hosted on [legacy.gitbook.com](https://gitbook.com).
+You can create an F.A.Q. with [GitBook](https://github.com/GitbookIO/gitbook). As a matter of fact, this Help Center is made with GitBook and hosted on [legacy.gitbook.com](https://legacy.gitbook.com).
 
 To create an F.A.Q., you can install and use the [theme-faq](https://plugins.gitbook.com/plugin/theme-faq). Soon, you will be able to choose a F.A.Q. template from the book creation page on GitBook.com.
 

--- a/basics/what-is-gitbook.md
+++ b/basics/what-is-gitbook.md
@@ -3,7 +3,7 @@ related:
   - basics/who-s-using-gitbook.md
 ---
 
-The legacy GitBook is both an [online platform](https://www.gitbook.com) for writing and hosting documentation, and an open source [book format and toolchain](https://github.com/GitbookIO/gitbook).
+The legacy GitBook is both an [online platform](https://legacy.gitbook.com) for writing and hosting documentation, and an open source [book format and toolchain](https://github.com/GitbookIO/gitbook).
 
 Hundreds of thousands of users use GitBook to write documentation \(library, API, tools, etc.\), or knowledge bases \(like this F.A.Q.\). People also use GitBook to publish technical books, teaching material, and many other things.
 

--- a/basics/what-is-gitbook.md
+++ b/basics/what-is-gitbook.md
@@ -1,8 +1,9 @@
 ---
 related:
-    - basics/who-s-using-gitbook.md
+  - basics/who-s-using-gitbook.md
 ---
 
-GitBook is both an [online platform](https://www.gitbook.com) for writing and hosting documentation, and an open source [book format and toolchain](https://github.com/GitbookIO/gitbook).
+The legacy GitBook is both an [online platform](https://www.gitbook.com) for writing and hosting documentation, and an open source [book format and toolchain](https://github.com/GitbookIO/gitbook).
 
-Hundreds of thousands of users use GitBook to write documentation (library, API, tools, etc.), or knowledge bases (like this F.A.Q.). People also use GitBook to publish technical books, teaching material, and many other things.
+Hundreds of thousands of users use GitBook to write documentation \(library, API, tools, etc.\), or knowledge bases \(like this F.A.Q.\). People also use GitBook to publish technical books, teaching material, and many other things.
+

--- a/books/how-can-i-delete-a-book.md
+++ b/books/how-can-i-delete-a-book.md
@@ -5,7 +5,7 @@ related:
 
 To delete a book:
 
-* Go to the book's home page (accessed from your dashboard, or at the URL `https://www.gitbook.com/book/username/bookname`)
+* Go to the book's home page (accessed from your dashboard, or at the URL `https://legacy.gitbook.com/book/username/bookname`)
 
 * Go to its settings tab:
   ![](/assets/book-settings.png)

--- a/books/how-can-i-transfer-ownership.md
+++ b/books/how-can-i-transfer-ownership.md
@@ -1,6 +1,6 @@
 To transfer ownership of a book to another user or to an organization:
 
-* Go to the book's home page (accessed from your dashboard, or at the URL `https://www.gitbook.com/book/username/bookname`)
+* Go to the book's home page (accessed from your dashboard, or at the URL `https://legacy.gitbook.com/book/username/bookname`)
 
 * Go to its settings tab:
   ![](/assets/book-settings.png)

--- a/books/how-can-i-use-git.md
+++ b/books/how-can-i-use-git.md
@@ -26,7 +26,7 @@ machine git.gitbook.com
   password API-TOKEN-or-PASSWORD
 ```
 
-We recommend using your **API TOKEN** for security reasons, you can find it [in your settings under "API"](https://www.gitbook.com/settings#api)
+We recommend using your **API TOKEN** for security reasons, you can find it [in your settings under "API"](https://legacy.gitbook.com/settings#api)
 
 ### Create a new repository on the command line
 

--- a/books/how-many-books.md
+++ b/books/how-many-books.md
@@ -1,3 +1,3 @@
-You can create up to 100 public books. Feel free to [contact us](https://www.gitbook.com/contact) if you plan on publishing more than 100 books.
+You can create up to 100 public books. Feel free to [contact us](https://legacy.gitbook.com/contact) if you plan on publishing more than 100 books.
 
-Limitation on private books depends on your account status. You will find details about the limitations on [our pricing page](https://www.gitbook.com/pricing).
+Limitation on private books depends on your account status. You will find details about the limitations on [our pricing page](https://legacy.gitbook.com/pricing).

--- a/books/will-my-book-be-accessible-with-https.md
+++ b/books/will-my-book-be-accessible-with-https.md
@@ -6,4 +6,4 @@ related:
 
 All content hosted on GitBook.com is accessible through HTTPS: the `gitbook.io` domain (URLs of the form `https://{author}.gitbooks.io/{book}/`) and custom domain names.
 
-All content are being served through [our speedy global CDN](https://www.gitbook.com/blog/features/gitbook-cdn), at no additional cost for all users.
+All content are being served through [our speedy global CDN](https://legacy.gitbook.com/blog/features/gitbook-cdn), at no additional cost for all users.

--- a/content/why-are-my-updates-failing.md
+++ b/content/why-are-my-updates-failing.md
@@ -1,3 +1,3 @@
 Content could fail to updates for multiple reasons: invalid configuration, unstable 3rd party plugins, etc.
 
-Feel free to post an issue on [GitHub](https://github.com/GitbookIO/gitbook/issues) or [Contact us](https://www.gitbook.com/contact). Provide us with as much essential information as possible (url of your failed update, etc).
+Feel free to post an issue on [GitHub](https://github.com/GitbookIO/gitbook/issues) or [Contact us](https://legacy.gitbook.com/contact). Provide us with as much essential information as possible (url of your failed update, etc).

--- a/editor/can-i-edit-offline.md
+++ b/editor/can-i-edit-offline.md
@@ -3,4 +3,4 @@ related:
     - editor/what-os-are-supported.md
 ---
 
-The [GitBook Editor](https://www.gitbook.com/editor) is released as a desktop application for Windows, Mac OS X and Linux, and supports offline editing. You can synchronize your modifications once you are back online, or when you feel ready, by simply clicking the "Sync" button.
+The [GitBook Editor](https://legacy.gitbook.com/editor) is released as a desktop application for Windows, Mac OS X and Linux, and supports offline editing. You can synchronize your modifications once you are back online, or when you feel ready, by simply clicking the "Sync" button.

--- a/editor/what-os-are-supported.md
+++ b/editor/what-os-are-supported.md
@@ -4,12 +4,12 @@ The web editor on GitBook.com supports all modern browsers: Internet Explorer (9
 
 ### Desktop Editor
 
-The [GitBook Desktop Editor](https://www.gitbook.com/editor) runs on **Windows**, **Mac OS X** and **Linux**.
+The [GitBook Desktop Editor](https://legacy.gitbook.com/editor) runs on **Windows**, **Mac OS X** and **Linux**.
 
 | Platform | Supported | Links |
 | -------- | --------- | ----- |
-| Windows | Windows 7 or later | [Download](https://www.gitbook.com/editor/windows/download) |
-| Mac OS X | OS X 10.9 or later | [Download](https://www.gitbook.com/editor/osx/download) |
-| Linux | Available as `.deb` for Ubuntu/Debian | [Download](https://www.gitbook.com/editor/linux/download) |
+| Windows | Windows 7 or later | [Download](https://legacy.gitbook.com/editor/windows/download) |
+| Mac OS X | OS X 10.9 or later | [Download](https://legacy.gitbook.com/editor/osx/download) |
+| Linux | Available as `.deb` for Ubuntu/Debian | [Download](https://legacy.gitbook.com/editor/linux/download) |
 
 

--- a/github/can-i-host-on-github.md
+++ b/github/can-i-host-on-github.md
@@ -30,7 +30,7 @@ First, you need to install our GitHub integration on the account of the owner of
   you want to sync your GitBook organization with and click on the **Install GitHub integration** button.
   ![](/assets/sync-github-org.png)
 
-- Otherwise, log in with your personal account. Go to the [GitHub section of your settings page](https://www.gitbook.com/settings/github)
+- Otherwise, log in with your personal account. Go to the [GitHub section of your settings page](https://legacy.gitbook.com/settings/github)
   and click on the **Install GitHub integration** button.
   ![](/assets/install-github-integration.png)
 

--- a/github/how-can-i-import-repo.md
+++ b/github/how-can-i-import-repo.md
@@ -1,4 +1,4 @@
-If you started writing your book on GitHub and now want to create a book using this repository, simply go to the [new book page](https://www.gitbook.com/new)
+If you started writing your book on GitHub and now want to create a book using this repository, simply go to the [new book page](https://legacy.gitbook.com/new)
 and select the **GitHub** option.
 
 If you have not already setup GitHub, you will be asked to install our GitHub integration and come back.

--- a/github/why-is-my-organization-not-listed.md
+++ b/github/why-is-my-organization-not-listed.md
@@ -18,4 +18,4 @@ If the GitBook application doesn't have access to the GitHub organization, you c
 ### Reconnecting your GitHub account
 
 After the access has been granted on GitHub, you must update your GitHub Access Token for the GitBook OAuth application.
-To do so, simply go to [your settings page](https://www.gitbook.com/settings/github) and click on `Reconnect GitHub Account`.
+To do so, simply go to [your settings page](https://legacy.gitbook.com/settings/github) and click on `Reconnect GitHub Account`.

--- a/home.md
+++ b/home.md
@@ -2,4 +2,5 @@
 search: false
 ---
 
-Welcome to the help center for the [GitBook.com](https://www.gitbook.com) platform, where you can learn how to create books, collaborate with people, and integrate with other services. If you are looking for details about the GitBook format, visit the [toolchain documentation](http://toolchain.gitbook.com/).
+Welcome to the help center for the **deprecated GitBook.com platform**, that lives at [**legacy**.gitbook.com](https://legacy.gitbook.com). Customers who have not yet migrated to the new version can still use the legacy service for the duration of the transition. To access the new version documentation, head to [docs.gitbook.com](https://docs.gitbook.com).
+

--- a/orgs/how-can-i-convert-user.md
+++ b/orgs/how-can-i-convert-user.md
@@ -15,7 +15,7 @@ If the user you're converting is already a member of other organizations, you mu
 
 ##### 3. Convert the account into an organization
 
-* Open your [account settings](https://www.gitbook.com/settings).
+* Open your [account settings](https://legacy.gitbook.com/settings).
 * Under "Transform account", enter the username of your new personnal account (see section 1.), click `Turn into an organization`.
 
 ##### 4. Sign in to your new user account

--- a/orgs/how-can-i-create.md
+++ b/orgs/how-can-i-create.md
@@ -3,4 +3,4 @@ related:
     - orgs/how-can-i-convert-user.md
 ---
 
-When you [create a new organization](https://www.gitbook.com/organizations/new) from scratch, it doesn't have any books associated with it. At any time, members of the organization with write permissions can add new books, or transfer existing books.
+When you [create a new organization](https://legacy.gitbook.com/organizations/new) from scratch, it doesn't have any books associated with it. At any time, members of the organization with write permissions can add new books, or transfer existing books.


### PR DESCRIPTION
Marking old docs as belonging to legacy GitBook

Removed parts concerning account creation (and pricing) and added entry about why one cannot create an account on the old version.